### PR TITLE
Use direction keys like 'DoubleUp' instead of codes like 1

### DIFF
--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -7,16 +7,16 @@ var lastAlert = 0;
 var started = new Date( ).getTime( );
 
 var DIRECTIONS = {
-    NONE: 0
-    , DoubleUp: 1
-    , SingleUp: 2
-    , FortyFiveUp: 3
-    , Flat: 4
-    , FortyFiveDown: 5
-    , SingleDown: 6
-    , DoubleDown: 7
-    , 'NOT COMPUTABLE': 8
-    , 'RATE OUT OF RANGE': 9
+    'NONE': 0,
+    'DoubleUp': 1,
+    'SingleUp': 2,
+    'FortyFiveUp': 3,
+    'Flat': 4,
+    'FortyFiveDown': 5,
+    'SingleDown': 6,
+    'DoubleDown': 7,
+    'NOT COMPUTABLE': 8,
+    'RATE OUT OF RANGE': 9
 };
 
 function directionToTrend(direction) {


### PR DESCRIPTION
This will prevent bugs and make the code more readable, it will also make the community maintained pebble app compatable with the endpoint used by @rajatgupta43's users
